### PR TITLE
Use API token for NocoDB API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NOCODB_API_TOKEN="api_key_here"
+NOCODB_BASE="app_base_here" # TODO: no need for this to be an env var

--- a/src/lib/nocodb_api.ts
+++ b/src/lib/nocodb_api.ts
@@ -1,8 +1,8 @@
-import { Api } from 'nocodb-sdk'
+import { Api } from 'nocodb-sdk';
 import { NOCODB_API_TOKEN } from '$env/static/private';
 export const nocodb_api = new Api({
-  baseURL: 'https://app.nocodb.com',
-  headers: {
-    'xc-token': NOCODB_API_TOKEN
-  }
-})
+	baseURL: 'https://app.nocodb.com',
+	headers: {
+		'xc-token': NOCODB_API_TOKEN
+	}
+});

--- a/src/lib/nocodb_api.ts
+++ b/src/lib/nocodb_api.ts
@@ -1,8 +1,8 @@
 import { Api } from 'nocodb-sdk'
-import { NOCODB_AUTH_TOKEN } from '$env/static/private';
+import { NOCODB_API_TOKEN } from '$env/static/private';
 export const nocodb_api = new Api({
   baseURL: 'https://app.nocodb.com',
   headers: {
-    'xc-auth': NOCODB_AUTH_TOKEN
+    'xc-token': NOCODB_API_TOKEN
   }
 })


### PR DESCRIPTION
Currently we are using a JWT session auth token which expires every 10 hours, we need to be using an API token instead.